### PR TITLE
Feat: Improve unique attrs performance

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -35,28 +35,5 @@ func AppendAttrsToGroup(groups []string, actualAttrs []slog.Attr, newAttrs ...sl
 
 // @TODO: should be recursive
 func UniqAttrs(attrs []slog.Attr) []slog.Attr {
-	return uniqByLast(attrs, func(item slog.Attr) string {
-		return item.Key
-	})
-}
-
-func uniqByLast[T any, U comparable](collection []T, iteratee func(item T) U) []T {
-	result := make([]T, 0, len(collection))
-	seen := make(map[U]int, len(collection))
-	seenIndex := 0
-
-	for _, item := range collection {
-		key := iteratee(item)
-
-		if index, ok := seen[key]; ok {
-			result[index] = item
-			continue
-		}
-
-		seen[key] = seenIndex
-		seenIndex++
-		result = append(result, item)
-	}
-
-	return result
+	return slices.CompactFunc(attrs, func(a slog.Attr, b slog.Attr) bool { return a.Key == b.Key })
 }

--- a/groups_test.go
+++ b/groups_test.go
@@ -58,3 +58,11 @@ func TestAppendAttrsToGroup(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkUniqAttrs(b *testing.B) {
+	var actualAttrs = []slog.Attr{slog.String("key1", "value1"), slog.String("key1", "value1"), slog.String("key2", "value2")}
+	for i := 0; i < b.N; i++ {
+		unique := UniqAttrs(actualAttrs)
+		_ = unique
+	}
+}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/samber/slog-common
cpu: AMD Ryzen 9 5950X 16-Core Processor            
             │ baseline.txt │               pr.txt                │
             │    sec/op    │   sec/op     vs base                │
UniqAttrs-32    77.78n ± 1%   12.37n ± 1%  -84.10% (p=0.000 n=10)

             │ baseline.txt │              pr.txt               │
             │     B/op     │   B/op    vs base                 │
UniqAttrs-32     128.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=10)

             │ baseline.txt │               pr.txt                │
             │  allocs/op   │ allocs/op   vs base                 │
UniqAttrs-32     1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```