### PR TITLE
Feat: Improve empty group edge case performance

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -8,11 +8,11 @@ import (
 )
 
 func AppendAttrsToGroup(groups []string, actualAttrs []slog.Attr, newAttrs ...slog.Attr) []slog.Attr {
-	actualAttrs = slices.Clone(actualAttrs)
-
 	if len(groups) == 0 {
 		return UniqAttrs(append(actualAttrs, newAttrs...))
 	}
+
+	actualAttrs = slices.Clone(actualAttrs)
 
 	for i := range actualAttrs {
 		attr := actualAttrs[i]

--- a/groups_test.go
+++ b/groups_test.go
@@ -58,3 +58,17 @@ func TestAppendAttrsToGroup(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkAppendAttrsToGroup(b *testing.B) {
+	b.Run("empty", func(b *testing.B) {
+		var (
+			groups      = []string{}
+			actualAttrs = []slog.Attr{slog.String("key1", "value1")}
+			newAttrs    = []slog.Attr{slog.String("key2", "value2")}
+		)
+		for i := 0; i < b.N; i++ {
+			actual := AppendAttrsToGroup(groups, actualAttrs, newAttrs...)
+			_ = actual
+		}
+	})
+}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/samber/slog-common
cpu: AMD Ryzen 9 5950X 16-Core Processor            
                      │ baseline.txt │               pr.txt                │
                      │    sec/op    │   sec/op     vs base                │
AppendAttrsToGroup-32    144.7n ± 3%   110.5n ± 3%  -23.61% (p=0.000 n=10)

                      │ baseline.txt │               pr.txt               │
                      │     B/op     │    B/op     vs base                │
AppendAttrsToGroup-32     208.0 ± 0%   160.0 ± 0%  -23.08% (p=0.000 n=10)

                      │ baseline.txt │               pr.txt               │
                      │  allocs/op   │ allocs/op   vs base                │
AppendAttrsToGroup-32     3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
```